### PR TITLE
Dashboard create budget conditional fix

### DIFF
--- a/silver_coin/budget/templates/dashboard.html
+++ b/silver_coin/budget/templates/dashboard.html
@@ -22,8 +22,12 @@
             <div class="card">
                 <div class="card-content">
                     <span class="card-title center">Dashboard</span>
-                    {% if recent_net_amount %}
-                        <span class="card-title center">NET Amount: <span {% if recent_net_amount > 0 %}class="positive-net"{% else %}class="negative-net"{% endif %}>${{ recent_net_amount|intcomma }}</span></span>
+                    {% if has_budget %}
+                        {% if recent_net_amount %}
+                            <span class="card-title center">NET Amount: <span {% if recent_net_amount > 0 %}class="positive-net"{% else %}class="negative-net"{% endif %}>${{ recent_net_amount|intcomma }}</span></span>
+                        {% else %}
+                            <span class="card-title center">No Budget Periods</span>
+                        {% endif %}
                     {% else %}
                         <div class="row">
                             <div class="col s12">


### PR DESCRIPTION
# Overview
Fixes the conditional on the dashboard that displays the create budget button if there are no `BudgetPeriod` instances.
# Changes
* Adjust dashboard conditional for budget creation