### PR TITLE
Add page titles and move back buttons to the top of the pages

### DIFF
--- a/silver_coin/budget/templates/amount/actual_amount_list.html
+++ b/silver_coin/budget/templates/amount/actual_amount_list.html
@@ -4,6 +4,12 @@
 {% block content %}
     <div class="row">
         <div class="col s12">
+            <a class="waves-effect waves-light btn blue" href="{% url 'budget_period' %}">Back</a>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col s12">
             <div class="card">
                 <div class="card-content">
                     <span class="card-title center">Incomes</span>
@@ -116,12 +122,6 @@
                     <span class="card-title center">NET Amount: <span {% if net_amount > 0 %}class="positive-net"{% else %}class="negative-net"{% endif %}>${{ net_amount|intcomma }}</span></span>
                 </div>
             </div>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col s12">
-            <a class="waves-effect waves-light btn blue" href="{% url 'budget_period' %}">Back</a>
         </div>
     </div>
 {% endblock %}

--- a/silver_coin/budget/templates/amount/actual_amount_list.html
+++ b/silver_coin/budget/templates/amount/actual_amount_list.html
@@ -4,21 +4,18 @@
 {% block content %}
     <div class="row">
         <div class="col s12">
-            <a class="waves-effect waves-light btn blue" href="{% url 'budget_period' %}">Back</a>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col s12">
             <div class="card">
                 <div class="card-content">
                     <span class="card-title center">Incomes</span>
                     <div class="row">
-                        <a href="{% url 'create_actual_income' period_id=period_id %}">
-                            <div class="col s2 offset-s10 waves-effect waves-light btn blue">
-                                Add Income
-                            </div>
-                        </a>
+                        <div class="col s2">
+                            <a class="waves-effect waves-light btn blue" href="{% url 'budget_period' %}">
+                                <i class="material-icons">arrow_back</i>
+                            </a>
+                        </div>
+                        <div class="col s2 offset-s8">
+                            <a href="{% url 'create_actual_income' period_id=period_id %}" class="waves-effect waves-light btn blue right">Add Income</a>
+                        </div>
                     </div>
                     {% if incomes %}
                         <table class="highlight">

--- a/silver_coin/budget/templates/amount/amount_delete.html
+++ b/silver_coin/budget/templates/amount/amount_delete.html
@@ -1,7 +1,5 @@
 {% extends 'base.html' %}
 
-{% block title %}Delete {{ type }}{% endblock %}
-
 {% block content %}
     <div class="row">
         <div class="col s12">

--- a/silver_coin/budget/templates/amount/amount_list.html
+++ b/silver_coin/budget/templates/amount/amount_list.html
@@ -4,6 +4,12 @@
 {% block content %}
     <div class="row">
         <div class="col s12">
+            <a class="waves-effect waves-light btn blue" href="{% url 'dashboard' %}">Back</a>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col s12">
             <div class="card">
                 <div class="card-content">
                     <span class="card-title center">Incomes</span>
@@ -105,12 +111,6 @@
                     <span class="card-title center">NET Amount: <span {% if net_amount > 0 %}class="positive-net"{% else %}class="negative-net"{% endif %}>${{ net_amount }}</span></span>
                 </div>
             </div>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col s12">
-            <a class="waves-effect waves-light btn blue" href="{% url 'dashboard' %}">Back</a>
         </div>
     </div>
 {% endblock %}

--- a/silver_coin/budget/templates/amount/amount_list.html
+++ b/silver_coin/budget/templates/amount/amount_list.html
@@ -4,21 +4,18 @@
 {% block content %}
     <div class="row">
         <div class="col s12">
-            <a class="waves-effect waves-light btn blue" href="{% url 'dashboard' %}">Back</a>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col s12">
             <div class="card">
                 <div class="card-content">
                     <span class="card-title center">Incomes</span>
                     <div class="row">
-                        <a href="{% url 'create_income' %}">
-                            <div class="col s2 offset-s10 waves-effect waves-light btn blue">
-                                Add Income
-                            </div>
-                        </a>
+                        <div class="col s2">
+                            <a class="waves-effect waves-light btn blue" href="{% url 'dashboard' %}">
+                                <i class="material-icons">arrow_back</i>
+                            </a>
+                        </div>
+                        <div class="col s2 offset-s8">
+                            <a href="{% url 'create_income' %}" class="waves-effect waves-light btn blue right">Add Income</a>
+                        </div>
                     </div>
                     {% if incomes %}
                         <table class="highlight">

--- a/silver_coin/budget/templates/amount/summary.html
+++ b/silver_coin/budget/templates/amount/summary.html
@@ -6,6 +6,13 @@
             <div class="card">
                 <div class="card-content">
                     <span class="card-title center">Expense Summary</span>
+                    <div class="row">
+                        <div class="col s12">
+                            <a class="waves-effect waves-light btn blue" href="{% url 'actual_amount' period_id=period_id %}">
+                                <i class="material-icons">arrow_back</i>
+                            </a>
+                        </div>
+                    </div>
                     <table class="highlight">
                         <thead>
                             <tr>
@@ -26,12 +33,6 @@
                     </table>
                 </div>
             </div>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col s12">
-            <a class="waves-effect waves-light btn blue" href="{% url 'actual_amount' period_id=period_id %}">Back</a>
         </div>
     </div>
 {% endblock %}

--- a/silver_coin/budget/templates/budget_period/budget_period_list.html
+++ b/silver_coin/budget/templates/budget_period/budget_period_list.html
@@ -3,21 +3,18 @@
 {% block content %}
     <div class="row">
         <div class="col s12">
-            <a class="waves-effect waves-light btn blue" href="{% url 'dashboard' %}">Back</a>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col s12">
             <div class="card">
                 <div class="card-content">
                     <span class="card-title center">Budget Period</span>
                     <div class="row">
-                        <a href="{% url 'create_budget_period' %}">
-                            <div class="col s2 offset-s10 waves-effect waves-light btn blue">
-                                Add Budget Period
-                            </div>
-                        </a>
+                        <div class="col s2">
+                            <a class="waves-effect waves-light btn blue" href="{% url 'dashboard' %}">
+                                <i class="material-icons">arrow_back</i>
+                            </a>
+                        </div>
+                        <div class="col s2 offset-s8">
+                            <a href="{% url 'create_budget_period' %}" class="waves-effect waves-light btn blue">Add Budget Period</a>
+                        </div>
                     </div>
                     {% if budget_periods %}
                         <table class="highlight">

--- a/silver_coin/budget/templates/budget_period/budget_period_list.html
+++ b/silver_coin/budget/templates/budget_period/budget_period_list.html
@@ -3,6 +3,12 @@
 {% block content %}
     <div class="row">
         <div class="col s12">
+            <a class="waves-effect waves-light btn blue" href="{% url 'dashboard' %}">Back</a>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col s12">
             <div class="card">
                 <div class="card-content">
                     <span class="card-title center">Budget Period</span>
@@ -41,12 +47,6 @@
                     {% endif %}
                 </div>
             </div>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col s12">
-            <a class="waves-effect waves-light btn blue" href="{% url 'dashboard' %}">Back</a>
         </div>
     </div>
 {% endblock %}

--- a/silver_coin/budget/templates/dashboard.html
+++ b/silver_coin/budget/templates/dashboard.html
@@ -2,7 +2,6 @@
 {% load static %}
 {% load humanize %}
 
-{% block title %}Welcome{% endblock %}
 {% block extra_js %}
     <script src="{% static 'js/initialise_select.js' %}"></script>
     <script>

--- a/silver_coin/budget/views/amount.py
+++ b/silver_coin/budget/views/amount.py
@@ -52,7 +52,8 @@ class AmountList(LoginRequiredMixin, ListView):
             expenses=expenses, 
             total_income=total_income, 
             total_expense=total_expense,
-            net_amount=Budget.objects.get(owner=self.request.user).net_amount()
+            net_amount=Budget.objects.get(owner=self.request.user).net_amount(),
+            page_title="Amounts"
         )
     
 class CheckBudgetExists():
@@ -80,7 +81,7 @@ class CreateIncome(LoginRequiredMixin, CheckBudgetExists, FormView):
     form_class = AmountForm
     success_url = reverse_lazy("amount")
     template_name = "amount/income_form.html"
-    extra_context = {"action": "Create", "type": "Income"}
+    extra_context = {"action": "Create", "type": "Income", "page_title": "Create Income"}
 
     def get_login_url(self):
         return reverse("login")
@@ -171,7 +172,7 @@ class EditIncome(CheckOwner, LoginRequiredMixin, UpdateView):
     form_class = IncomeForm
     success_url = reverse_lazy("amount")
     template_name = "amount/income_form.html"
-    extra_context = {"action": "Edit", "type": "Income"}
+    extra_context = {"action": "Edit", "type": "Income", "page_title": "Edit Income"}
 
     def get_queryset(self):
         """
@@ -191,7 +192,7 @@ class DeleteIncome(CheckOwner, LoginRequiredMixin, DeleteView):
     model = Amount
     success_url = reverse_lazy("amount")
     template_name = "amount/amount_delete.html"
-    extra_context = {"type": "Income"}
+    extra_context = {"type": "Income", "page_title": "Delete Income"}
     
     def get_queryset(self):
         """
@@ -208,7 +209,7 @@ class CreateExpense(LoginRequiredMixin, CheckBudgetExists, FormView):
     form_class = AmountForm
     success_url = reverse_lazy("amount")
     template_name = "amount/expense_form.html"
-    extra_context = {"action": "Create", "type": "Expense"}
+    extra_context = {"action": "Create", "type": "Expense", "page_title": "Create Expense"}
 
     def get_login_url(self):
         return reverse("login")
@@ -244,7 +245,7 @@ class EditExpense(CheckOwner, LoginRequiredMixin, UpdateView):
     form_class = IncomeForm
     success_url = reverse_lazy("amount")
     template_name = "amount/expense_form.html"
-    extra_context = {"action": "Edit", "type": "Expense"}
+    extra_context = {"action": "Edit", "type": "Expense", "page_title": "Edit Expense"}
 
     def get_queryset(self):
         """
@@ -264,7 +265,7 @@ class DeleteExpense(LoginRequiredMixin, DeleteView):
     model = Amount
     success_url = reverse_lazy("amount")
     template_name = "amount/amount_delete.html"
-    extra_context = {"type": "Expense"}
+    extra_context = {"type": "Expense", "page_title": "Delete Expense"}
     
     def get_queryset(self):
         """
@@ -306,6 +307,7 @@ class ActualAmountList(LoginRequiredMixin, ListView):
             total_income=total_income, 
             total_expense=total_expense,
             net_amount=total_income - total_expense,
+            page_title="Actual Amounts"
         )
     
     def get(self, request, *args, **kwargs):
@@ -408,7 +410,8 @@ class CreateActualIncome(LoginRequiredMixin, FormView):
             **kwargs,
             period_id=self.kwargs["period_id"],
             action="Create",
-            type="Income"
+            type="Income",
+            page_title="Create Actual Income",
         )
 
         form = context["form"]
@@ -478,7 +481,8 @@ class EditActualIncome(LoginRequiredMixin, UpdateView):
             **kwargs,
             period_id=self.kwargs["period_id"],
             action="Edit",
-            type="Income"
+            type="Income",
+            page_title="Edit Actual Income",
         )
 
         form = context["form"]
@@ -534,7 +538,7 @@ class DeleteActualIncome(LoginRequiredMixin, DeleteView):
     model = ActualAmount
     template_name = "amount/actual_amount_delete.html"
     context_object_name = "actual_amount"
-    extra_context = {"type": "Income"}
+    extra_context = {"type": "Income", "page_title": "Delete Actual Income"}
     
     def get_queryset(self):
         """
@@ -564,7 +568,8 @@ class CreateActualExpense(LoginRequiredMixin, FormView):
             **kwargs,
             period_id=self.kwargs["period_id"],
             action="Create",
-            type="Expense"
+            type="Expense",
+            page_title="Add Actual Expense",
         )
 
         form = context["form"]
@@ -634,7 +639,8 @@ class EditActualExpense(LoginRequiredMixin, UpdateView):
             **kwargs,
             period_id=self.kwargs["period_id"],
             action="Edit",
-            type="Income"
+            type="Expense",
+            page_title="Edit Actual Expense",
         )
 
         form = context["form"]
@@ -690,7 +696,7 @@ class DeleteActualExpense(LoginRequiredMixin, DeleteView):
     model = ActualAmount
     template_name = "amount/actual_amount_delete.html"
     context_object_name = "actual_amount"
-    extra_context = {"type": "Expense"}
+    extra_context = {"type": "Expense", "page_title": "Delete Actual Expense"}
     
     def get_queryset(self):
         """

--- a/silver_coin/budget/views/budget.py
+++ b/silver_coin/budget/views/budget.py
@@ -18,7 +18,7 @@ class CreateBudget(LoginRequiredMixin, FormView):
     form_class = BudgetForm
     template_name = "budget/budget_form.html"
     success_url = reverse_lazy("dashboard")
-    extra_context = {"action": "Create"}
+    extra_context = {"action": "Create", "page_title": "Create Budget"}
 
     def get_login_url(self):
         return reverse("login")
@@ -66,7 +66,7 @@ class EditBudget(UserMixin, UpdateView):
     form_class = BudgetModelForm
     template_name = "budget/budget_form.html"
     success_url = reverse_lazy("dashboard")
-    extra_context = {"action": "Edit"}
+    extra_context = {"action": "Edit", "page_title": "Edit Budget"}
 
     
     
@@ -76,3 +76,4 @@ class DeleteBudget(UserMixin, DeleteView):
     """
     template_name = "budget/budget_delete.html"
     success_url = reverse_lazy("dashboard")
+    extra_context = {"page_title": "Delete Budget"}

--- a/silver_coin/budget/views/budget_period.py
+++ b/silver_coin/budget/views/budget_period.py
@@ -14,6 +14,7 @@ class BudgetPeriodList(LoginRequiredMixin, ListView):
     model = BudgetPeriod
     template_name = "budget_period/budget_period_list.html"
     context_object_name = "budget_periods"
+    extra_context = {"page_title": "Budget Periods"}
 
     def get_login_url(self):
         return reverse("login")
@@ -32,7 +33,7 @@ class CreateBudgetPeriod(LoginRequiredMixin, FormView):
     form_class = BudgetPeriodForm
     template_name = "budget_period/budget_period_form.html"
     success_url = reverse_lazy("budget_period")
-    extra_context = {"action": "Create"}
+    extra_context = {"action": "Create", "page_title": "Create Period"}
 
     def post(self, request, *args, **kwargs):
         owner = request.user
@@ -60,7 +61,7 @@ class EditBudgetPeriod(LoginRequiredMixin, UpdateView):
     success_url = reverse_lazy("budget_period")
     model = BudgetPeriod
     context_object_name = "budget_period"
-    extra_context = {"action": "Edit"}
+    extra_context = {"action": "Edit", "page_title": "Edit Period"}
         
 class DeleteBudgetPeriod(LoginRequiredMixin, DeleteView):
     """
@@ -70,3 +71,4 @@ class DeleteBudgetPeriod(LoginRequiredMixin, DeleteView):
     success_url = reverse_lazy("budget_period")
     model = BudgetPeriod
     context_object_name = "budget_period"
+    extra_context = {"page_title": "Delete Period"}

--- a/silver_coin/budget/views/dashboard.py
+++ b/silver_coin/budget/views/dashboard.py
@@ -7,16 +7,18 @@ from ..models import Budget, BudgetPeriod
 class DashboardView(LoginRequiredMixin, TemplateView):
     template_name = "dashboard.html"
 
-    def get(self, request, *args, **kwargs):
-        """
-        Override to check if the user has a budget defined.
-        """
-        has_budget = Budget.objects.filter(owner=request.user).count() > 0
-        last_period = BudgetPeriod.objects.filter(budget__owner=request.user).last()
+    def get_context_data(self, **kwargs):
+        has_budget = Budget.objects.filter(owner=self.request.user).count() > 0
+        last_period = BudgetPeriod.objects.filter(budget__owner=self.request.user).last()
 
         recent_net_amount = last_period.net_amount() if last_period else None
 
-        return super().get(request, has_budget=has_budget, recent_net_amount=recent_net_amount)
+        return super().get_context_data(
+            **kwargs,
+            has_budget=has_budget,
+            recent_net_amount=recent_net_amount,
+            page_title="Dasboard"
+        )
 
     def get_login_url(self):
         """

--- a/silver_coin/templates/base.html
+++ b/silver_coin/templates/base.html
@@ -5,6 +5,7 @@
         <title>{% block title %}{% endblock %}</title>
         <link rel="stylesheet" href="{% static 'css/materialize.min.css' %}">
         <link rel="stylesheet" href="{% static 'css/site.css' %}">
+        <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
         <script src="{% static 'js/materialize.min.js' %}"></script>
         {% block extra_js %}{% endblock %}
     </head>

--- a/silver_coin/templates/base.html
+++ b/silver_coin/templates/base.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>{% block title %}{% endblock %}</title>
+        <title>Silver Coin | {{ page_title }}</title>
         <link rel="stylesheet" href="{% static 'css/materialize.min.css' %}">
         <link rel="stylesheet" href="{% static 'css/site.css' %}">
         <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">


### PR DESCRIPTION
# Overview
Adds missing page titles to pages and moves the back buttons to the top of the pages.
# Changes
* Context is now given a `page_title` which is used in the templates
* Back button is now at the top of the page and is now an arrow